### PR TITLE
fixes encode/decode

### DIFF
--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -3,11 +3,11 @@ class JsonWebToken
 
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i
-    JWT.encode(payload, HMAC_SECRET)
+    JWT.encode(payload, HMAC_SECRET, 'HS256')
   end
 
   def self.decode(token)
-    body = JWT.decode(token, HMAC_SECRET)[0]
+    body, = JWT.decode(token, HMAC_SECRET, true, { algorithm: 'HS256' })
     HashWithIndifferentAccess.new body
   rescue JWT::DecodeError => e
     raise ExceptionHandler::InvalidToken, e.message


### PR DESCRIPTION
Fixes encode/decode library to work correctly, when trying to decode the library was failing due to lack of information since a jwt gem change was introduced. This PR fixes that making it workable again.